### PR TITLE
Fix broken links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ If you have `CI=true` in your environment, the graphical interface won't get pul
 ## Exercises
 
 Using the provided simulation and the documentation provided on [the official Alchemist website](https://alchemistsimulator.github.io/),
-and in particular in [the guide to write YAML simulations](https://alchemistsimulator.github.io/wiki/usage/yaml/) and
-in [the SAPERE incarnation page](https://alchemistsimulator.github.io/wiki/usage/sapere/),
-and the graphical interface usage description available [here](https://alchemistsimulator.github.io/wiki/usage/gui/),
+and in particular in [the guide to write YAML simulations](https://alchemistsimulator.github.io/wiki/use/basics/) and
+in [the SAPERE incarnation page](https://alchemistsimulator.github.io/wiki/incarnations/sapere/),
+and the graphical interface usage description available [here](https://alchemistsimulator.github.io/wiki/prepare/default-gui/),
 try to solve the following exercises:
 
 1. Add two nodes to an empty, continuous environment, and make them connected


### PR DESCRIPTION
I've found broken links to docs. I think those new links could be used instead.